### PR TITLE
Install php-xml

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2020.03
+FROM cimg/base:2020.05
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -16,11 +16,12 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		php$PHP_MINOR-curl \
 		php$PHP_MINOR-gd \
 		php$PHP_MINOR-json \
-		php$PHP_MINOR-mysql && \
+		php$PHP_MINOR-mysql \
+		php$PHP_MINOR-xml && \
 	sudo rm -rf /var/lib/apt/lists/*
 
 # Install the PHP package manager Composer
-ENV COMPOSER_VERSION 1.10.1
+ENV COMPOSER_VERSION 1.10.6
 ENV COMPOSER_SHA e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a
 
 RUN sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \

--- a/5.6/node/Dockerfile
+++ b/5.6/node/Dockerfile
@@ -4,14 +4,12 @@ FROM cimg/php:5.6.40
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-# Version hardcoded for now in this repo. Eventually once:
-# https://github.com/CircleCI-Public/cimg-node/issues/16 is completed, this
 # Dockerfile will pull the latest LTS release from cimg-node.
-ENV NODE_VERSION 12.16.1
-
-RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/master/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
 	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
-	rm node.tar.xz && \
+	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 ENV YARN_VERSION 1.22.4

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -16,7 +16,8 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		php$PHP_MINOR-curl \
 		php$PHP_MINOR-gd \
 		php$PHP_MINOR-json \
-		php$PHP_MINOR-mysql && \
+		php$PHP_MINOR-mysql \
+		php$PHP_MINOR-xml && \
 	sudo rm -rf /var/lib/apt/lists/*
 
 # Install the PHP package manager Composer

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -16,7 +16,8 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		php$PHP_MINOR-curl \
 		php$PHP_MINOR-gd \
 		php$PHP_MINOR-json \
-		php$PHP_MINOR-mysql && \
+		php$PHP_MINOR-mysql \
+		php$PHP_MINOR-xml && \
 	sudo rm -rf /var/lib/apt/lists/*
 
 # Install the PHP package manager Composer

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -16,7 +16,8 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		php$PHP_MINOR-curl \
 		php$PHP_MINOR-gd \
 		php$PHP_MINOR-json \
-		php$PHP_MINOR-mysql && \
+		php$PHP_MINOR-mysql \
+		php$PHP_MINOR-xml && \
 	sudo rm -rf /var/lib/apt/lists/*
 
 # Install the PHP package manager Composer

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -16,7 +16,8 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		php$PHP_MINOR-curl \
 		php$PHP_MINOR-gd \
 		php$PHP_MINOR-json \
-		php$PHP_MINOR-mysql && \
+		php$PHP_MINOR-mysql \
+		php$PHP_MINOR-xml && \
 	sudo rm -rf /var/lib/apt/lists/*
 
 # Install the PHP package manager Composer

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+docker build --file 5.6/Dockerfile -t cimg/php:5.6.40  -t cimg/php:5.6 .
+docker build --file 5.6/node/Dockerfile -t cimg/php:5.6.40-node  -t cimg/php:5.6-node .
 docker build --file 7.2/Dockerfile -t cimg/php:7.2.31  -t cimg/php:7.2 .
 docker build --file 7.2/node/Dockerfile -t cimg/php:7.2.31-node  -t cimg/php:7.2-node .
 docker build --file 7.3/Dockerfile -t cimg/php:7.3.18  -t cimg/php:7.3 .


### PR DESCRIPTION
Add `php-xml` to docker images because squizlabs/php_codesniffer requires ext-simplexml. Given the popularity of phpcs, installing `php-xml` should help lots of users removing these lines from their `.circleci/config.yml`

```
    steps:
      - run: sudo apt-get update
      # Because squizlabs/php_codesniffer requires ext-simplexml.
      - run: sudo apt-get install -y php<< parameters.version >>-xml
```

Note: The php 7.4 edit is for consistency only (i.e: unnecessary) because php 7.4 already has php-xml bundled.