### PR TITLE
Fix composer cannot install global packages

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2020.03
+FROM cimg/base:2020.05
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
@@ -20,10 +20,19 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	sudo rm -rf /var/lib/apt/lists/*
 
 # Install the PHP package manager Composer
-ENV COMPOSER_VERSION 1.10.1
+ENV COMPOSER_VERSION 1.10.6
 ENV COMPOSER_SHA e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a
 
-RUN sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-	sudo php -r "if (hash_file('sha384', 'composer-setup.php') === '${COMPOSER_SHA}') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+	ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")" && \
+	if [ "$COMPOSER_SHA" != "$ACTUAL_CHECKSUM" ]; \
+	then \
+		>&2 echo 'ERROR: Invalid installer checksum'; \
+		rm composer-setup.php; \
+		exit 1; \
+	fi && \
 	sudo php composer-setup.php --version=$COMPOSER_VERSION --install-dir=/usr/local/bin --filename=composer && \
-	sudo php -r "unlink('composer-setup.php');"
+	RESULT=$? && \
+	rm composer-setup.php && \
+	sudo chown $(whoami):$(whoami) $HOME/.composer && \
+	exit $RESULT

--- a/5.6/node/Dockerfile
+++ b/5.6/node/Dockerfile
@@ -4,14 +4,12 @@ FROM cimg/php:5.6.40
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-# Version hardcoded for now in this repo. Eventually once:
-# https://github.com/CircleCI-Public/cimg-node/issues/16 is completed, this
 # Dockerfile will pull the latest LTS release from cimg-node.
-ENV NODE_VERSION 12.16.1
-
-RUN curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/master/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
 	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
-	rm node.tar.xz && \
+	rm node.tar.xz nodeAliases.txt && \
 	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 ENV YARN_VERSION 1.22.4

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -23,7 +23,16 @@ RUN sudo apt-get update && sudo apt-get install -y \
 ENV COMPOSER_VERSION 1.10.6
 ENV COMPOSER_SHA e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a
 
-RUN sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-	sudo php -r "if (hash_file('sha384', 'composer-setup.php') === '${COMPOSER_SHA}') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+	ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")" && \
+	if [ "$COMPOSER_SHA" != "$ACTUAL_CHECKSUM" ]; \
+	then \
+		>&2 echo 'ERROR: Invalid installer checksum'; \
+		rm composer-setup.php; \
+		exit 1; \
+	fi && \
 	sudo php composer-setup.php --version=$COMPOSER_VERSION --install-dir=/usr/local/bin --filename=composer && \
-	sudo php -r "unlink('composer-setup.php');"
+	RESULT=$? && \
+	rm composer-setup.php && \
+	sudo chown $(whoami):$(whoami) $HOME/.composer && \
+	exit $RESULT

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -23,7 +23,16 @@ RUN sudo apt-get update && sudo apt-get install -y \
 ENV COMPOSER_VERSION 1.10.6
 ENV COMPOSER_SHA e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a
 
-RUN sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-	sudo php -r "if (hash_file('sha384', 'composer-setup.php') === '${COMPOSER_SHA}') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+	ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")" && \
+	if [ "$COMPOSER_SHA" != "$ACTUAL_CHECKSUM" ]; \
+	then \
+		>&2 echo 'ERROR: Invalid installer checksum'; \
+		rm composer-setup.php; \
+		exit 1; \
+	fi && \
 	sudo php composer-setup.php --version=$COMPOSER_VERSION --install-dir=/usr/local/bin --filename=composer && \
-	sudo php -r "unlink('composer-setup.php');"
+	RESULT=$? && \
+	rm composer-setup.php && \
+	sudo chown $(whoami):$(whoami) $HOME/.composer && \
+	exit $RESULT

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -23,7 +23,16 @@ RUN sudo apt-get update && sudo apt-get install -y \
 ENV COMPOSER_VERSION 1.10.6
 ENV COMPOSER_SHA e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a
 
-RUN sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-	sudo php -r "if (hash_file('sha384', 'composer-setup.php') === '${COMPOSER_SHA}') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+	ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")" && \
+	if [ "$COMPOSER_SHA" != "$ACTUAL_CHECKSUM" ]; \
+	then \
+		>&2 echo 'ERROR: Invalid installer checksum'; \
+		rm composer-setup.php; \
+		exit 1; \
+	fi && \
 	sudo php composer-setup.php --version=$COMPOSER_VERSION --install-dir=/usr/local/bin --filename=composer && \
-	sudo php -r "unlink('composer-setup.php');"
+	RESULT=$? && \
+	rm composer-setup.php && \
+	sudo chown $(whoami):$(whoami) $HOME/.composer && \
+	exit $RESULT

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -23,7 +23,16 @@ RUN sudo apt-get update && sudo apt-get install -y \
 ENV COMPOSER_VERSION 1.10.6
 ENV COMPOSER_SHA e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a
 
-RUN sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-	sudo php -r "if (hash_file('sha384', 'composer-setup.php') === '${COMPOSER_SHA}') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+	ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")" && \
+	if [ "$COMPOSER_SHA" != "$ACTUAL_CHECKSUM" ]; \
+	then \
+		>&2 echo 'ERROR: Invalid installer checksum'; \
+		rm composer-setup.php; \
+		exit 1; \
+	fi && \
 	sudo php composer-setup.php --version=$COMPOSER_VERSION --install-dir=/usr/local/bin --filename=composer && \
-	sudo php -r "unlink('composer-setup.php');"
+	RESULT=$? && \
+	rm composer-setup.php && \
+	sudo chown $(whoami):$(whoami) $HOME/.composer && \
+	exit $RESULT

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+docker build --file 5.6/Dockerfile -t cimg/php:5.6.40  -t cimg/php:5.6 .
+docker build --file 5.6/node/Dockerfile -t cimg/php:5.6.40-node  -t cimg/php:5.6-node .
 docker build --file 7.2/Dockerfile -t cimg/php:7.2.31  -t cimg/php:7.2 .
 docker build --file 7.2/node/Dockerfile -t cimg/php:7.2.31-node  -t cimg/php:7.2-node .
 docker build --file 7.3/Dockerfile -t cimg/php:7.3.18  -t cimg/php:7.3 .


### PR DESCRIPTION
- Update composer install script to match https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
- Avoid sudo whenever possible
- Set `~/.composer` owner to `circleci:circleci`

#### The issue

`~/.composer` is owned by `root:root` which makes `$ composer global require xxx/yyy` fails.

```sh-session
$ docker run -it cimg/php:7.4

circleci@27240a54c7be:~/project$ ls -la ~
total 28
drwxr-xr-x 1 circleci circleci 4096 May 12 18:00 .
drwxr-xr-x 1 root     root     4096 May 12 18:00 ..
-rw-r--r-- 1 circleci circleci  220 Apr  4  2018 .bash_logout
-rw-r--r-- 1 circleci circleci 3771 Apr  4  2018 .bashrc
drwxr-xr-x 2 root     root     4096 May 12 18:00 .composer
-rw-r--r-- 1 circleci circleci  807 Apr  4  2018 .profile
drwxr-xr-x 1 circleci circleci 4096 May 12 18:00 project

circleci@40f5991b0833:~/project$ composer global require psr/log
Changed current directory to /home/circleci/.composer


  [ErrorException]
  file_put_contents(./composer.json): failed to open stream: Permission denie
  d


require [--dev] [--prefer-source] [--prefer-dist] [--fixed] [--no-progress] [--no-suggest] [--no-update] [--no-scripts] [--update-no-dev] [--update-with-dependencies] [--update-with-all-dependencies] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [--sort-packages] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--] [<packages>]...
```