### PR TITLE
PATH includes Compser 2.0 global bin-dir

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -34,4 +34,4 @@ RUN sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php')
 	sudo php composer-setup.php --version=$COMPOSER_VERSION --install-dir=/usr/local/bin --filename=composer && \
 	sudo php -r "unlink('composer-setup.php');" && \
 	composer --version
-ENV PATH /home/circleci/.composer/vendor/bin:$PATH
+ENV PATH /home/circleci/.config/composer/vendor/bin:/home/circleci/.composer/vendor/bin:$PATH


### PR DESCRIPTION
Closes #90. The `PATH` environment variable includes the path for both Composer 2.x and Composer 1.x global bin directories. 

With this PR, the following code should work, whether we run version 1.10.x or 2.x.

```shell
$ composer global require "squizlabs/php_codesniffer=*"
Changed current directory to /home/circleci/.config/composer
./composer.json has been updated
Running composer update squizlabs/php_codesniffer
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking squizlabs/php_codesniffer (3.5.8)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
Generating autoload files
$ phpcs --version
PHP_CodeSniffer version 3.5.8 (stable) by Squiz (http://www.squiz.net)