### PR TITLE
Avoid a changing installer, also includes v2.0.7

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -26,11 +26,8 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	sudo rm -rf /var/lib/apt/lists/*
 
 # Install the PHP package manager Composer
-ENV COMPOSER_VERSION 2.0.4
-ENV COMPOSER_SHA c31c1e292ad7be5f49291169c0ac8f683499edddcfd4e42232982d0fd193004208a58ff6f353fde0012d35fdd72bc394
-
+ENV COMPOSER_VERSION 2.0.7
 RUN sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-	sudo php -r "if (hash_file('sha384', 'composer-setup.php') === '${COMPOSER_SHA}') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
 	sudo php composer-setup.php --version=$COMPOSER_VERSION --install-dir=/usr/local/bin --filename=composer && \
 	sudo php -r "unlink('composer-setup.php');" && \
 	composer --version


### PR DESCRIPTION
The Composer installer is versioned separately from Composer itself and
constantly changes. This means old Dockerfiles for this image won't
build once the installer version changes. This makes them
non-Deterministic. This PR fixes that.

Also updates to Composer v2.0.7.