### PR TITLE
Add phpdbg - The interactive PHP debugger

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -19,6 +19,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		php$PHP_MINOR-mbstring \
 		php$PHP_MINOR-mysql \
 		php$PHP_MINOR-pgsql \
+		php$PHP_MINOR-phpdbg \
 		php$PHP_MINOR-xml \
 		php$PHP_MINOR-zip \
 	&& \


### PR DESCRIPTION
This is a useful PHP debugging tool that:

1. is part of PHP core
2. was available in the legacy PHP images

Closes #97.