### PR TITLE
Custom compile PHP and push 8.0.12

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,36 +1,55 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/base:2021.07
+FROM cimg/base:2021.10
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV PHP_VERSION 8.0.11
+ENV PHP_VERSION 8.0.12
 ENV PHP_MINOR 8.0
 
-RUN sudo add-apt-repository -y ppa:ondrej/php && \
-	sudo apt-get install -y php${PHP_MINOR} php${PHP_MINOR}-dev && \
-	sudo rm -rf /var/lib/apt/lists/*
-
-# Pre-install a few very popular PHP extensions
+# Install dependencies
 RUN sudo apt-get update && sudo apt-get install -y \
-		php$PHP_MINOR-bcmath \
-		php$PHP_MINOR-curl \
-		php$PHP_MINOR-gd \
-		php$PHP_MINOR-mbstring \
-		php$PHP_MINOR-mysql \
-		php$PHP_MINOR-pgsql \
-		php$PHP_MINOR-phpdbg \
-		php$PHP_MINOR-xml \
-		php$PHP_MINOR-zip \
+		autoconf \
+		bison \
+		build-essential \
+		libcurl4-openssl-dev \
+		libonig-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		libtool \
+		libxml2-dev \
+		re2c \
+		zlib1g-dev \
 	&& \
-	# Only install the JSON extension in PHP 5 and 7
-	if (( 8 <= 7 )); then \
-		sudo apt-get install -y php$PHP_MINOR-json; \
-	fi && \
-	sudo rm -rf /var/lib/apt/lists/*
+	sudo rm -rf /var/lib/apt/lists/* && \
+
+	curl -sSL "https://www.php.net/distributions/php-${PHP_VERSION}.tar.gz" | tar -xz && \
+	cd "php-${PHP_VERSION}" && \
+	./buildconf && \
+	./configure \
+		--enable-bcmath \
+		--enable-mbstring \
+		--enable-phpdbg \
+		--enable-zip \
+		--with-curl \
+		--with-gd \
+		--with-mysqli \
+		--with-pdo-mysql \
+		--with-pdo-pgsql \
+		--with-pgsql \
+		--with-openssl \
+		--with-readline \
+		--with-zlib \
+	&& \
+	make -j $(nproc) && \
+	sudo make install && \
+	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
+	cd .. && \
+	rm -r php-${PHP_VERSION}
 
 # Install the PHP package manager Composer
-ENV COMPOSER_VERSION 2.1.7
+ENV COMPOSER_VERSION 2.1.12
 RUN sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
 	sudo php composer-setup.php --version=$COMPOSER_VERSION --install-dir=/usr/local/bin --filename=composer && \
 	sudo php -r "unlink('composer-setup.php');" && \

--- a/8.0/browsers/Dockerfile
+++ b/8.0/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:8.0.11-node
+FROM cimg/php:8.0.12-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/8.0/node/Dockerfile
+++ b/8.0/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:8.0.11
+FROM cimg/php:8.0.12
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,37 +1,55 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/%%PARENT%%:2021.07
+FROM cimg/%%PARENT%%:2021.10
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV PHP_VERSION %%MAIN_VERSION%%
+ENV PHP_VERSION %%VERSION_FULL%%
 ENV PHP_MINOR %%VERSION_MINOR%%
 
-RUN sudo add-apt-repository -y ppa:ondrej/php && \
-	sudo apt-get install -y php${PHP_MINOR} php${PHP_MINOR}-dev && \
-	sudo rm -rf /var/lib/apt/lists/*
-
-# Pre-install a few very popular PHP extensions
+# Install dependencies
 RUN sudo apt-get update && sudo apt-get install -y \
-		php$PHP_MINOR-bcmath \
-		php$PHP_MINOR-curl \
-		php$PHP_MINOR-gd \
-		php$PHP_MINOR-mbstring \
-		php$PHP_MINOR-mysql \
-		php$PHP_MINOR-pgsql \
-		php$PHP_MINOR-phpdbg \
-		php$PHP_MINOR-xml \
-		php$PHP_MINOR-zip \
+		autoconf \
+		bison \
+		build-essential \
+		libcurl4-openssl-dev \
+		libonig-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		libssl-dev \
+		libtool \
+		libxml2-dev \
+		re2c \
+		zlib1g-dev \
 	&& \
-	# Only install the JSON extension in PHP 5 and 7
-	if (( %%VERSION_MAJOR%% <= 7 )); then \
-		sudo apt-get install -y php$PHP_MINOR-json; \
-	fi && \
 	sudo rm -rf /var/lib/apt/lists/* && \
-	php --version | grep "${PHP_VERSION}" || echo "Error: PHP version installed is not correct." && exit 1
+
+	curl -sSL "https://www.php.net/distributions/php-${PHP_VERSION}.tar.gz" | tar -xz && \
+	cd "php-${PHP_VERSION}" && \
+	./buildconf && \
+	./configure \
+		--enable-bcmath \
+		--enable-mbstring \
+		--enable-phpdbg \
+		--enable-zip \
+		--with-curl \
+		--with-gd \
+		--with-mysqli \
+		--with-pdo-mysql \
+		--with-pdo-pgsql \
+		--with-pgsql \
+		--with-openssl \
+		--with-readline \
+		--with-zlib \
+	&& \
+	make -j $(nproc) && \
+	sudo make install && \
+	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
+	cd .. && \
+	rm -r php-${PHP_VERSION}
 
 # Install the PHP package manager Composer
-ENV COMPOSER_VERSION 2.1.7
+ENV COMPOSER_VERSION 2.1.12
 RUN sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
 	sudo php composer-setup.php --version=$COMPOSER_VERSION --install-dir=/usr/local/bin --filename=composer && \
 	sudo php -r "unlink('composer-setup.php');" && \

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-docker build --file 7.3/Dockerfile -t cimg/php:7.3.31  -t cimg/php:7.3 .
-docker build --file 7.3/node/Dockerfile -t cimg/php:7.3.31-node  -t cimg/php:7.3-node .
-docker build --file 7.3/browsers/Dockerfile -t cimg/php:7.3.31-browsers  -t cimg/php:7.3-browsers .
-docker build --file 7.4/Dockerfile -t cimg/php:7.4.24  -t cimg/php:7.4 .
-docker build --file 7.4/node/Dockerfile -t cimg/php:7.4.24-node  -t cimg/php:7.4-node .
-docker build --file 7.4/browsers/Dockerfile -t cimg/php:7.4.24-browsers  -t cimg/php:7.4-browsers .
-docker build --file 8.0/Dockerfile -t cimg/php:8.0.11  -t cimg/php:8.0 .
-docker build --file 8.0/node/Dockerfile -t cimg/php:8.0.11-node  -t cimg/php:8.0-node .
-docker build --file 8.0/browsers/Dockerfile -t cimg/php:8.0.11-browsers  -t cimg/php:8.0-browsers .
+docker build --file 8.0/Dockerfile -t cimg/php:8.0.12  -t cimg/php:8.0 .
+docker build --file 8.0/node/Dockerfile -t cimg/php:8.0.12-node  -t cimg/php:8.0-node .
+docker build --file 8.0/browsers/Dockerfile -t cimg/php:8.0.12-browsers  -t cimg/php:8.0-browsers .


### PR DESCRIPTION
This PHP image is switching from using the sem-official PPA to custom compiling PHP on our image. We did a short test to see if this includes all of the extensions users need. It was put out as a GitHub Issue here (#126) as well as a Discuss post.

This PR merges in the official change to the image and re-spins v8.0.12 with it. After this PR is merged, the next step is to publish PHP versions we've been missing since the PPA became a problem. Shouldn't be too large of a list.