### PR TITLE
Add additional extensions [release]

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -4,7 +4,7 @@ FROM cimg/base:2021.10
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV PHP_VERSION 7.3.33
+ENV PHP_VERSION 7.3.32
 ENV PHP_MINOR 7.3
 
 # Install dependencies
@@ -13,12 +13,18 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		bison \
 		build-essential \
 		libcurl4-openssl-dev \
+		libfreetype6-dev \
+		libjpeg-dev \
 		libonig-dev \
+		libpng-dev \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
+		libxpm-dev \
+		libzip-dev \
 		re2c \
 		zlib1g-dev \
 	&& \
@@ -29,24 +35,43 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	./buildconf && \
 	./configure \
 		--enable-bcmath \
+		--enable-fpm \
+		--enable-gd \
+		--enable-intl \
 		--enable-mbstring \
 		--enable-phpdbg \
+		--enable-sockets \
+		--enable-exif \
 		--enable-zip \
+		--with-config-file-scan-dir=/etc/php.d \
 		--with-curl \
-		--with-gd \
-		--with-mysqli \
-		--with-pdo-mysql \
+		--with-freetype \
+		--with-jpeg \
+		--with-mysqli=mysqlnd \
+		--with-pear \
+		--with-pdo-mysql=mysqlnd \
 		--with-pdo-pgsql \
+		--with-pdo-sqlite \
 		--with-pgsql \
 		--with-openssl \
 		--with-readline \
+		--with-webp \
+		--with-xpm \
+		--with-zip \
 		--with-zlib \
 	&& \
 	make -j $(nproc) && \
 	sudo make install && \
-	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
 	cd .. && \
-	rm -r php-${PHP_VERSION}
+	rm -r php-${PHP_VERSION} && \
+	sudo mkdir -p /etc/php.d && \
+	echo 'memory_limit = -1' | sudo tee -a /etc/php.d/circleci.ini && \
+	pear config-set php_init /etc/php.d/circleci.ini && \
+
+	# Check things are as they should be
+	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
+	php -m | grep "gd" && \
+	php -m | grep "sockets"
 
 # Install the PHP package manager Composer
 ENV COMPOSER_VERSION 2.1.12

--- a/7.3/browsers/Dockerfile
+++ b/7.3/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:7.3.33-node
+FROM cimg/php:7.3.32-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/7.3/node/Dockerfile
+++ b/7.3/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:7.3.33
+FROM cimg/php:7.3.32
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -4,7 +4,7 @@ FROM cimg/base:2021.10
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV PHP_VERSION 7.4.26
+ENV PHP_VERSION 7.4.25
 ENV PHP_MINOR 7.4
 
 # Install dependencies
@@ -13,12 +13,18 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		bison \
 		build-essential \
 		libcurl4-openssl-dev \
+		libfreetype6-dev \
+		libjpeg-dev \
 		libonig-dev \
+		libpng-dev \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
+		libxpm-dev \
+		libzip-dev \
 		re2c \
 		zlib1g-dev \
 	&& \
@@ -29,24 +35,43 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	./buildconf && \
 	./configure \
 		--enable-bcmath \
+		--enable-fpm \
+		--enable-gd \
+		--enable-intl \
 		--enable-mbstring \
 		--enable-phpdbg \
+		--enable-sockets \
+		--enable-exif \
 		--enable-zip \
+		--with-config-file-scan-dir=/etc/php.d \
 		--with-curl \
-		--with-gd \
-		--with-mysqli \
-		--with-pdo-mysql \
+		--with-freetype \
+		--with-jpeg \
+		--with-mysqli=mysqlnd \
+		--with-pear \
+		--with-pdo-mysql=mysqlnd \
 		--with-pdo-pgsql \
+		--with-pdo-sqlite \
 		--with-pgsql \
 		--with-openssl \
 		--with-readline \
+		--with-webp \
+		--with-xpm \
+		--with-zip \
 		--with-zlib \
 	&& \
 	make -j $(nproc) && \
 	sudo make install && \
-	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
 	cd .. && \
-	rm -r php-${PHP_VERSION}
+	rm -r php-${PHP_VERSION} && \
+	sudo mkdir -p /etc/php.d && \
+	echo 'memory_limit = -1' | sudo tee -a /etc/php.d/circleci.ini && \
+	pear config-set php_init /etc/php.d/circleci.ini && \
+
+	# Check things are as they should be
+	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
+	php -m | grep "gd" && \
+	php -m | grep "sockets"
 
 # Install the PHP package manager Composer
 ENV COMPOSER_VERSION 2.1.12

--- a/7.4/browsers/Dockerfile
+++ b/7.4/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:7.4.26-node
+FROM cimg/php:7.4.25-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/7.4/node/Dockerfile
+++ b/7.4/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:7.4.26
+FROM cimg/php:7.4.25
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -4,7 +4,7 @@ FROM cimg/base:2021.10
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV PHP_VERSION 8.0.13
+ENV PHP_VERSION 8.0.12
 ENV PHP_MINOR 8.0
 
 # Install dependencies
@@ -13,12 +13,18 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		bison \
 		build-essential \
 		libcurl4-openssl-dev \
+		libfreetype6-dev \
+		libjpeg-dev \
 		libonig-dev \
+		libpng-dev \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
+		libxpm-dev \
+		libzip-dev \
 		re2c \
 		zlib1g-dev \
 	&& \
@@ -29,24 +35,43 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	./buildconf && \
 	./configure \
 		--enable-bcmath \
+		--enable-fpm \
+		--enable-gd \
+		--enable-intl \
 		--enable-mbstring \
 		--enable-phpdbg \
+		--enable-sockets \
+		--enable-exif \
 		--enable-zip \
+		--with-config-file-scan-dir=/etc/php.d \
 		--with-curl \
-		--with-gd \
-		--with-mysqli \
-		--with-pdo-mysql \
+		--with-freetype \
+		--with-jpeg \
+		--with-mysqli=mysqlnd \
+		--with-pear \
+		--with-pdo-mysql=mysqlnd \
 		--with-pdo-pgsql \
+		--with-pdo-sqlite \
 		--with-pgsql \
 		--with-openssl \
 		--with-readline \
+		--with-webp \
+		--with-xpm \
+		--with-zip \
 		--with-zlib \
 	&& \
 	make -j $(nproc) && \
 	sudo make install && \
-	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
 	cd .. && \
-	rm -r php-${PHP_VERSION}
+	rm -r php-${PHP_VERSION} && \
+	sudo mkdir -p /etc/php.d && \
+	echo 'memory_limit = -1' | sudo tee -a /etc/php.d/circleci.ini && \
+	pear config-set php_init /etc/php.d/circleci.ini && \
+
+	# Check things are as they should be
+	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
+	php -m | grep "gd" && \
+	php -m | grep "sockets"
 
 # Install the PHP package manager Composer
 ENV COMPOSER_VERSION 2.1.12

--- a/8.0/browsers/Dockerfile
+++ b/8.0/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:8.0.13-node
+FROM cimg/php:8.0.12-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/8.0/node/Dockerfile
+++ b/8.0/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:8.0.13
+FROM cimg/php:8.0.12
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -13,12 +13,18 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		bison \
 		build-essential \
 		libcurl4-openssl-dev \
+		libfreetype6-dev \
+		libjpeg-dev \
 		libonig-dev \
+		libpng-dev \
 		libreadline-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libtool \
+		libwebp-dev \
 		libxml2-dev \
+		libxpm-dev \
+		libzip-dev \
 		re2c \
 		zlib1g-dev \
 	&& \
@@ -29,24 +35,43 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	./buildconf && \
 	./configure \
 		--enable-bcmath \
+		--enable-fpm \
+		--enable-gd \
+		--enable-intl \
 		--enable-mbstring \
 		--enable-phpdbg \
+		--enable-sockets \
+		--enable-exif \
 		--enable-zip \
+		--with-config-file-scan-dir=/etc/php.d \
 		--with-curl \
-		--with-gd \
-		--with-mysqli \
-		--with-pdo-mysql \
+		--with-freetype \
+		--with-jpeg \
+		--with-mysqli=mysqlnd \
+		--with-pear \
+		--with-pdo-mysql=mysqlnd \
 		--with-pdo-pgsql \
+		--with-pdo-sqlite \
 		--with-pgsql \
 		--with-openssl \
 		--with-readline \
+		--with-webp \
+		--with-xpm \
+		--with-zip \
 		--with-zlib \
 	&& \
 	make -j $(nproc) && \
 	sudo make install && \
-	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
 	cd .. && \
-	rm -r php-${PHP_VERSION}
+	rm -r php-${PHP_VERSION} && \
+	sudo mkdir -p /etc/php.d && \
+	echo 'memory_limit = -1' | sudo tee -a /etc/php.d/circleci.ini && \
+	pear config-set php_init /etc/php.d/circleci.ini && \
+
+	# Check things are as they should be
+	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
+	php -m | grep "gd" && \
+	php -m | grep "sockets"
 
 # Install the PHP package manager Composer
 ENV COMPOSER_VERSION 2.1.12

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-docker build --file 7.3/Dockerfile -t cimg/php:7.3.33  -t cimg/php:7.3 .
-docker build --file 7.3/node/Dockerfile -t cimg/php:7.3.33-node  -t cimg/php:7.3-node .
-docker build --file 7.3/browsers/Dockerfile -t cimg/php:7.3.33-browsers  -t cimg/php:7.3-browsers .
-docker build --file 7.4/Dockerfile -t cimg/php:7.4.26  -t cimg/php:7.4 .
-docker build --file 7.4/node/Dockerfile -t cimg/php:7.4.26-node  -t cimg/php:7.4-node .
-docker build --file 7.4/browsers/Dockerfile -t cimg/php:7.4.26-browsers  -t cimg/php:7.4-browsers .
+docker build --file 7.3/Dockerfile -t cimg/php:7.3.32  -t cimg/php:7.3 .
+docker build --file 7.3/node/Dockerfile -t cimg/php:7.3.32-node  -t cimg/php:7.3-node .
+docker build --file 7.3/browsers/Dockerfile -t cimg/php:7.3.32-browsers  -t cimg/php:7.3-browsers .
+docker build --file 7.4/Dockerfile -t cimg/php:7.4.25  -t cimg/php:7.4 .
+docker build --file 7.4/node/Dockerfile -t cimg/php:7.4.25-node  -t cimg/php:7.4-node .
+docker build --file 7.4/browsers/Dockerfile -t cimg/php:7.4.25-browsers  -t cimg/php:7.4-browsers .
+docker build --file 8.0/Dockerfile -t cimg/php:8.0.12  -t cimg/php:8.0 .
+docker build --file 8.0/node/Dockerfile -t cimg/php:8.0.12-node  -t cimg/php:8.0-node .
+docker build --file 8.0/browsers/Dockerfile -t cimg/php:8.0.12-browsers  -t cimg/php:8.0-browsers .


### PR DESCRIPTION
Adds additional extensions to the new compiled PHP image that were missing. This PR rolls it out to PHP versions 7.3.32, 7.4.25, and 8.0.12.

Adds:

- the pear and pecl commands
- zip extension
- properly adds gd
- adds libs for jpg, png, and webp
- and others