### PR TITLE
Finalize the new PHP image [release]

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -4,7 +4,7 @@ FROM cimg/base:2021.10
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV PHP_VERSION 7.3.33
+ENV PHP_VERSION 7.3.32
 ENV PHP_MINOR 7.3
 
 # Install dependencies
@@ -69,9 +69,14 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	rm -r php-${PHP_VERSION} && \
 	sudo mkdir -p /etc/php.d && \
 	echo 'memory_limit = -1' | sudo tee -a /etc/php.d/circleci.ini && \
-	#sudo pear config-set php_init /etc/php.d/circleci.ini && \
+	sudo pear config-set php_init /etc/php.d/circleci.ini && \
+	sudo pecl update-channels && \
 
 	# Check things are as they should be
+	# We likely don't need to test EVERYTHING here. What is important is to
+	# test for extensions where the installation method has changed between
+	# releases. For example, if we decide to use this template back for older
+	# PHP releases, the way `gd` is enabled at compile time changed.
 	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
 	php -m | grep "gd" && \
 	php -m | grep "sockets"

--- a/7.3/browsers/Dockerfile
+++ b/7.3/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:7.3.33-node
+FROM cimg/php:7.3.32-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/7.3/node/Dockerfile
+++ b/7.3/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:7.3.33
+FROM cimg/php:7.3.32
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -4,7 +4,7 @@ FROM cimg/base:2021.10
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV PHP_VERSION 7.4.26
+ENV PHP_VERSION 7.4.25
 ENV PHP_MINOR 7.4
 
 # Install dependencies
@@ -69,9 +69,14 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	rm -r php-${PHP_VERSION} && \
 	sudo mkdir -p /etc/php.d && \
 	echo 'memory_limit = -1' | sudo tee -a /etc/php.d/circleci.ini && \
-	#sudo pear config-set php_init /etc/php.d/circleci.ini && \
+	sudo pear config-set php_init /etc/php.d/circleci.ini && \
+	sudo pecl update-channels && \
 
 	# Check things are as they should be
+	# We likely don't need to test EVERYTHING here. What is important is to
+	# test for extensions where the installation method has changed between
+	# releases. For example, if we decide to use this template back for older
+	# PHP releases, the way `gd` is enabled at compile time changed.
 	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
 	php -m | grep "gd" && \
 	php -m | grep "sockets"

--- a/7.4/browsers/Dockerfile
+++ b/7.4/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:7.4.26-node
+FROM cimg/php:7.4.25-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/7.4/node/Dockerfile
+++ b/7.4/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:7.4.26
+FROM cimg/php:7.4.25
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -4,7 +4,7 @@ FROM cimg/base:2021.10
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV PHP_VERSION 8.0.13
+ENV PHP_VERSION 8.0.12
 ENV PHP_MINOR 8.0
 
 # Install dependencies
@@ -69,9 +69,14 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	rm -r php-${PHP_VERSION} && \
 	sudo mkdir -p /etc/php.d && \
 	echo 'memory_limit = -1' | sudo tee -a /etc/php.d/circleci.ini && \
-	#sudo pear config-set php_init /etc/php.d/circleci.ini && \
+	sudo pear config-set php_init /etc/php.d/circleci.ini && \
+	sudo pecl update-channels && \
 
 	# Check things are as they should be
+	# We likely don't need to test EVERYTHING here. What is important is to
+	# test for extensions where the installation method has changed between
+	# releases. For example, if we decide to use this template back for older
+	# PHP releases, the way `gd` is enabled at compile time changed.
 	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
 	php -m | grep "gd" && \
 	php -m | grep "sockets"

--- a/8.0/browsers/Dockerfile
+++ b/8.0/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:8.0.13-node
+FROM cimg/php:8.0.12-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/8.0/node/Dockerfile
+++ b/8.0/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/php:8.0.13
+FROM cimg/php:8.0.12
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -69,9 +69,14 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	rm -r php-${PHP_VERSION} && \
 	sudo mkdir -p /etc/php.d && \
 	echo 'memory_limit = -1' | sudo tee -a /etc/php.d/circleci.ini && \
-	#sudo pear config-set php_init /etc/php.d/circleci.ini && \
+	sudo pear config-set php_init /etc/php.d/circleci.ini && \
+	sudo pecl update-channels && \
 
 	# Check things are as they should be
+	# We likely don't need to test EVERYTHING here. What is important is to
+	# test for extensions where the installation method has changed between
+	# releases. For example, if we decide to use this template back for older
+	# PHP releases, the way `gd` is enabled at compile time changed.
 	php --version | grep "${PHP_VERSION}" || ( echo "Error: PHP version installed is not correct." && exit 1 ) && \
 	php -m | grep "gd" && \
 	php -m | grep "sockets"

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ For example:
 jobs:
   build:
     docker:
-      - image: cimg/php:7.4.14
+      - image: cimg/php:7.4.26
     steps:
       - checkout
       - run: php --version
 ```
 
 In the above example, the CircleCI PHP Docker image is used for the primary container.
-More specifically, the tag `7.4.12` is used meaning the version of PHP will be PHP v7.4.12.
+More specifically, the tag `7.4.26` is used meaning the version of PHP will be PHP v7.4.26.
 You can now use PHP within the steps for this job.
 
 
@@ -52,14 +52,16 @@ This image contains the PHP programming language as well as Composer and a few v
 
 ### PHP Extensions
 
-This image is based on Ubuntu.
-This means you can install additional PHP extensions as you would on an Ubuntu-based server.
-Many PHP extension Apt packages are available to install as a convenience.
-For example, to install the PHP BCrypt extension (already pre-installed), you would run the following in your CircleCI config:
+This image contains [PEAR](https://pear.php.net/) and [PECL](https://pecl.php.net/).
+These tools can be used to install various PHP extensions and utilities.
+For example, to install pcov, the following command can be run:
 
 ```bash
-sudo apt-get update && sudo apt-get install -y php-bcrypt
+sudo pecl install pcov
 ```
+
+Older versions of this image suggested installing extensions via `apt-get`.
+This is no longer the suggested route unless you are providing your own source of packages and know exactly what you are doing.
 
 ### Composer v2
 
@@ -83,7 +85,7 @@ The Node.js variant can be used by appending `-node` to the end of an existing `
 jobs:
   build:
     docker:
-      - image: cimg/php:7.4.14-node
+      - image: cimg/php:7.4.26-node
     steps:
       - checkout
       - run: php --version
@@ -103,7 +105,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/php:7.4.14-browsers
+      - image: cimg/php:7.4.26-browsers
     steps:
       - browser-tools/install-browser-tools
       - checkout
@@ -123,12 +125,12 @@ cimg/php:<php-version>[-variant]
 ```
 
 `<php-version>` - The version of PHP to use.
-This can be a full SemVer point release (such as `7.3.11`) or just the minor release (such as `7.3`).
+This can be a full SemVer point release (such as `7.4.25`) or just the minor release (such as `7.4`).
 If you use the minor release tag, it will automatically point to future patch updates as they are released by the PHP Team.
-For example, the tag `7.3` points to PHP v7.3.11 now, but when the next release comes out, it will point to PHP v7.3.12.
+For example, the tag `7.4` points to PHP v7.4.25 now, but when the next release comes out, it will point to PHP v7.4.26.
 
 `[-variant]` - Variant tags, if available, can optionally be used.
-For example, the Node.js variant could be used like this: `cimg/php:7.3-node`.
+For example, the Node.js variant could be used like this: `cimg/php:7.4-node`.
 
 
 ## Development
@@ -168,10 +170,10 @@ git clone --recurse-submodules git@github.com:CircleCI-Public/cimg-php.git
 ### Generating Dockerfiles
 
 Dockerfiles can be generated for a specific PHP version using the `gen-dockerfiles.sh` script.
-For example, to generate the Dockerfile for PHP v7.3.11, you would run the following from the root of the repo:
+For example, to generate the Dockerfile for PHP v7.4.26, you would run the following from the root of the repo:
 
 ```bash
-./shared/gen-dockerfiles.sh 7.3.11
+./shared/gen-dockerfiles.sh 7.4.26
 ```
 
 The generated Dockerfile will be located at `./7.3/Dockefile`.

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-docker build --file 7.3/Dockerfile -t cimg/php:7.3.33  -t cimg/php:7.3 .
-docker build --file 7.3/node/Dockerfile -t cimg/php:7.3.33-node  -t cimg/php:7.3-node .
-docker build --file 7.3/browsers/Dockerfile -t cimg/php:7.3.33-browsers  -t cimg/php:7.3-browsers .
-docker build --file 7.4/Dockerfile -t cimg/php:7.4.26  -t cimg/php:7.4 .
-docker build --file 7.4/node/Dockerfile -t cimg/php:7.4.26-node  -t cimg/php:7.4-node .
-docker build --file 7.4/browsers/Dockerfile -t cimg/php:7.4.26-browsers  -t cimg/php:7.4-browsers .
-docker build --file 8.0/Dockerfile -t cimg/php:8.0.13  -t cimg/php:8.0 .
-docker build --file 8.0/node/Dockerfile -t cimg/php:8.0.13-node  -t cimg/php:8.0-node .
-docker build --file 8.0/browsers/Dockerfile -t cimg/php:8.0.13-browsers  -t cimg/php:8.0-browsers .
+docker build --file 7.3/Dockerfile -t cimg/php:7.3.32  .
+docker build --file 7.3/node/Dockerfile -t cimg/php:7.3.32-node .
+docker build --file 7.3/browsers/Dockerfile -t cimg/php:7.3.32-browsers .
+docker build --file 7.4/Dockerfile -t cimg/php:7.4.25 .
+docker build --file 7.4/node/Dockerfile -t cimg/php:7.4.25-node .
+docker build --file 7.4/browsers/Dockerfile -t cimg/php:7.4.25-browsers .
+docker build --file 8.0/Dockerfile -t cimg/php:8.0.12 .
+docker build --file 8.0/node/Dockerfile -t cimg/php:8.0.12-node .
+docker build --file 8.0/browsers/Dockerfile -t cimg/php:8.0.12-browsers .


### PR DESCRIPTION
This PR is to finalize the last week of changes to the PHP image, ultimately moving from a PPA reliant image to a compiled PHP one.

This PR:

1. Sets the default config file for pecl (commented out in the last PR).
2. Updates the readme docs with the new suggested way to install extensions
3. Respins the first 3 of 6 tags. Part 2 will respin the second 3. These will be the last respins for these 6 images. They will now follow the normal policy of no respins unless there's a major problem.
4. Removed the alias tags from the build script as these are the latest patch versions.