### PR TITLE
Add arm64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.0
+  cimg: circleci/cimg@0.3.3
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.3
+  cimg: circleci/cimg@0.3.4
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 
@@ -23,6 +23,7 @@ workflows:
     jobs:
       - cimg/build-and-deploy:
           name: "Staging"
+          resource-class: 2xlarge+
           docker-namespace: ccitest
           docker-repository: php
           publish-branch: test
@@ -39,6 +40,7 @@ workflows:
           context: cimg-publishing
       - cimg/build-and-deploy:
           name: "Deploy"
+          resource-class: 2xlarge+
           docker-repository: php
           filters:
             branches:

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=php
 parent=base
 variants=(node browsers)
 namespace=cimg
+arm64=1


### PR DESCRIPTION
# Description
This PR adds multi architecture images with arm64 support

# Reasons
Enables arm64 support using the updating tooling in cimg-shared and cimg-orb

Test build: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-php/678/workflows/70a334e5-2f98-4673-9d0a-94458f84423c/jobs/688

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
