### PR TITLE
Update Dockerfile.template COMPOSER_VERSION

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -107,7 +107,7 @@ RUN sudo mkdir -p "$PHP_INI_DIR/conf.d"  && \
 	sudo chmod +x /usr/local/bin/docker-php-* /usr/local/bin/install-php-extensions
 
 # Install the PHP package manager Composer
-ENV COMPOSER_VERSION=2.7.7
+ENV COMPOSER_VERSION=2.8.4
 RUN sudo php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
 	sudo php composer-setup.php --version=$COMPOSER_VERSION --install-dir=/usr/local/bin --filename=composer && \
 	sudo php -r "unlink('composer-setup.php');" && \


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Updates `COMPOSER_VERSION` to version latest version 2.8.4 which fixes some composer deprecation messages added with PHP 8.4

# Reasons
Fix for PHP 8.4 was added to composer in version 2.8.0

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [X] I have made changes to the `Dockerfile.template` file only
- [X] I have not made any manual changes to automatically generated files
- [X] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
